### PR TITLE
Maven dependency updates (version 2)

### DIFF
--- a/resteasy-spring-boot-starter/pom.xml
+++ b/resteasy-spring-boot-starter/pom.xml
@@ -57,11 +57,6 @@
             <version>${springboot.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-            <version>${springboot.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
             <version>${resteasy.version}</version>


### PR DESCRIPTION
Cleanup the spring-boot-starter-web dependency.  This starter
only needs spring-boot-starter